### PR TITLE
Update1.5v

### DIFF
--- a/ExomeGermlineSingleSample.wdl
+++ b/ExomeGermlineSingleSample.wdl
@@ -28,23 +28,23 @@ version 1.0
 ## page at https://hub.docker.com/r/broadinstitute/genomes-in-the-cloud/ for detailed
 ## licensing information pertaining to the included programs.
 
-import "https://raw.githubusercontent.com/gatk-workflows/gatk4-exome-analysis-pipeline/1.2.0/tasks/UnmappedBamToAlignedBam.wdl" as ToBam
-import "https://raw.githubusercontent.com/gatk-workflows/gatk4-exome-analysis-pipeline/1.2.0/tasks/AggregatedBamQC.wdl" as AggregatedQC
-import "https://raw.githubusercontent.com/gatk-workflows/gatk4-exome-analysis-pipeline/1.2.0/tasks/Qc.wdl" as QC
-import "https://raw.githubusercontent.com/gatk-workflows/gatk4-exome-analysis-pipeline/1.2.0/tasks/BamProcessing.wdl" as Processing
-import "https://raw.githubusercontent.com/gatk-workflows/gatk4-exome-analysis-pipeline/1.2.0/tasks/BamToCram.wdl" as ToCram
-import "https://raw.githubusercontent.com/gatk-workflows/gatk4-exome-analysis-pipeline/1.2.0/tasks/VariantCalling.wdl" as ToGvcf
-import "https://raw.githubusercontent.com/gatk-workflows/gatk4-exome-analysis-pipeline/1.2.0/structs/GermlineStructs.wdl"
+import "./tasks/UnmappedBamToAlignedBam.wdl" as ToBam
+import "./tasks/AggregatedBamQC.wdl" as AggregatedQC
+import "./tasks/Qc.wdl" as QC
+import "./tasks/BamProcessing.wdl" as Processing
+import "./tasks/BamToCram.wdl" as ToCram
+import "./tasks/VariantCalling.wdl" as ToGvcf
+import "./structs/GermlineStructs.wdl"
 
 # WORKFLOW DEFINITION
 workflow ExomeGermlineSingleSample {
 
-  String pipeline_version = "1.3"
+  String pipeline_version = "1.5"
 
   input {
     PapiSettings papi_settings
     SampleAndUnmappedBams sample_and_unmapped_bams
-    GermlineSingleSampleReferences references
+    DNASeqSingleSampleReferences references
     File target_interval_list
     File bait_interval_list
     File bait_set_name

--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ This WDL pipeline implements data pre-processing and initial variant calling acc
 ### Software version notes :
 - GATK 4 or later 
 - Cromwell version support 
-  - Successfully tested on v44 
-  - Does not work on versions < v23 due to output syntax
+  - Successfully tested on v50 
 
 ### Important Notes :
 - Runtime parameters are optimized for Broad's Google Cloud Platform implementation.
@@ -37,6 +36,6 @@ view the following tutorial [(How to) Execute Workflows from the gatk-workflows 
 - The following material is provided by the Data Science Platforum group at the Broad Institute. Please direct any questions or concerns to one of our forum sites : [GATK](https://gatk.broadinstitute.org/hc/en-us/community/topics) or [Terra](https://support.terra.bio/hc/en-us/community/topics/360000500432).
 
 ### LICENSING :
-Copyright Broad Institute, 2019 | BSD-3
+Copyright Broad Institute, 2020 | BSD-3
 
 This script is released under the WDL open source code license (BSD-3) (full license text at https://github.com/openwdl/wdl/blob/master/LICENSE). Note however that the programs it calls may be subject to different licenses. Users are responsible for checking that they are authorized to run all programs before running this script.

--- a/structs/GermlineStructs.wdl
+++ b/structs/GermlineStructs.wdl
@@ -20,7 +20,7 @@ struct ReferenceFasta {
   File ref_pac
 }
 
-struct GermlineSingleSampleReferences {
+struct DNASeqSingleSampleReferences {
   File? fingerprint_genotypes_file
   File? fingerprint_genotypes_index
 
@@ -41,6 +41,7 @@ struct GermlineSingleSampleReferences {
   File dbsnp_vcf_index
 
   File evaluation_interval_list
+
 }
 
 struct ExomeGermlineSingleSampleOligos {

--- a/tasks/AggregatedBamQC.wdl
+++ b/tasks/AggregatedBamQC.wdl
@@ -15,8 +15,8 @@ version 1.0
 ## page at https://hub.docker.com/r/broadinstitute/genomes-in-the-cloud/ for detailed
 ## licensing information pertaining to the included programs.
 
-import "https://raw.githubusercontent.com/gatk-workflows/gatk4-exome-analysis-pipeline/1.2.0/tasks/Qc.wdl" as QC
-import "https://raw.githubusercontent.com/gatk-workflows/gatk4-exome-analysis-pipeline/1.2.0/structs/GermlineStructs.wdl"
+import "../tasks/Qc.wdl" as QC
+import "../structs/GermlineStructs.wdl"
 
 # WORKFLOW DEFINITION
 workflow AggregatedBamQC {
@@ -27,7 +27,7 @@ input {
     String sample_name
     String recalibrated_bam_base_name
     File? haplotype_database_file
-    GermlineSingleSampleReferences references
+    DNASeqSingleSampleReferences references
     PapiSettings papi_settings
   }
 

--- a/tasks/Alignment.wdl
+++ b/tasks/Alignment.wdl
@@ -15,7 +15,7 @@ version 1.0
 ## page at https://hub.docker.com/r/broadinstitute/genomes-in-the-cloud/ for detailed
 ## licensing information pertaining to the included programs.
 
-import "https://raw.githubusercontent.com/gatk-workflows/gatk4-exome-analysis-pipeline/1.2.0/structs/GermlineStructs.wdl"
+import "../structs/GermlineStructs.wdl"
 
 # Get version of BWA
 task GetBwaVersion {
@@ -50,6 +50,7 @@ task SamToFastqAndBwaMemAndMba {
 
     Int compression_level
     Int preemptible_tries
+    Boolean hard_clip_reads = false
   }
 
   Float unmapped_bam_size = size(input_bam, "GiB")
@@ -91,6 +92,8 @@ task SamToFastqAndBwaMemAndMba {
         IS_BISULFITE_SEQUENCE=false \
         ALIGNED_READS_ONLY=false \
         CLIP_ADAPTERS=false \
+        ~{true='CLIP_OVERLAPPING_READS=true' false="" hard_clip_reads} \
+        ~{true='CLIP_OVERLAPPING_READS_OPERATOR=H' false="" hard_clip_reads} \
         MAX_RECORDS_IN_RAM=2000000 \
         ADD_MATE_CIGAR=true \
         MAX_INSERTIONS_OR_DELETIONS=-1 \
@@ -113,7 +116,7 @@ task SamToFastqAndBwaMemAndMba {
     fi
   >>>
   runtime {
-    docker: "us.gcr.io/broad-gotc-prod/genomes-in-the-cloud:2.4.3-1564508330"
+    docker: "us.gcr.io/broad-gotc-prod/genomes-in-the-cloud:2.4.3-1564508330" # TODO: update docker to use the new Picard options
     preemptible: preemptible_tries
     memory: "14 GiB"
     cpu: "16"

--- a/tasks/BamProcessing.wdl
+++ b/tasks/BamProcessing.wdl
@@ -25,7 +25,7 @@ task SortSam {
   }
   # SortSam spills to disk a lot more because we are only store 300000 records in RAM now because its faster for our data so it needs
   # more disk space.  Also it spills to disk in an uncompressed format so we need to account for that with a larger multiplier
-  Float sort_sam_disk_multiplier = 3.25
+  Float sort_sam_disk_multiplier = 4.25
   Int disk_size = ceil(sort_sam_disk_multiplier * size(input_bam, "GiB")) + 20
 
   command {

--- a/tasks/BamProcessing.wdl
+++ b/tasks/BamProcessing.wdl
@@ -25,7 +25,7 @@ task SortSam {
   }
   # SortSam spills to disk a lot more because we are only store 300000 records in RAM now because its faster for our data so it needs
   # more disk space.  Also it spills to disk in an uncompressed format so we need to account for that with a larger multiplier
-  Float sort_sam_disk_multiplier = 4.25
+  Float sort_sam_disk_multiplier = 6.25
   Int disk_size = ceil(sort_sam_disk_multiplier * size(input_bam, "GiB")) + 20
 
   command {

--- a/tasks/BamToCram.wdl
+++ b/tasks/BamToCram.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/gatk-workflows/gatk4-exome-analysis-pipeline/1.2.0/tasks/Utilities.wdl" as Utils
-import "https://raw.githubusercontent.com/gatk-workflows/gatk4-exome-analysis-pipeline/1.2.0/tasks/Qc.wdl" as QC
+import "../tasks/Utilities.wdl" as Utils
+import "../tasks/Qc.wdl" as QC
 
 workflow BamToCram {
 

--- a/tasks/SplitLargeReadGroup.wdl
+++ b/tasks/SplitLargeReadGroup.wdl
@@ -15,12 +15,13 @@ version 1.0
 ## page at https://hub.docker.com/r/broadinstitute/genomes-in-the-cloud/ for detailed
 ## licensing information pertaining to the included programs.
 
-import "https://raw.githubusercontent.com/gatk-workflows/gatk4-exome-analysis-pipeline/1.2.0/tasks/Alignment.wdl" as Alignment
-import "https://raw.githubusercontent.com/gatk-workflows/gatk4-exome-analysis-pipeline/1.2.0/tasks/BamProcessing.wdl" as Processing
-import "https://raw.githubusercontent.com/gatk-workflows/gatk4-exome-analysis-pipeline/1.2.0/tasks/Utilities.wdl" as Utils
-import "https://raw.githubusercontent.com/gatk-workflows/gatk4-exome-analysis-pipeline/1.2.0/structs/GermlineStructs.wdl" as Structs
+import "../tasks/Alignment.wdl" as Alignment
+import "../tasks/BamProcessing.wdl" as Processing
+import "../tasks/Utilities.wdl" as Utils
+import "../structs/GermlineStructs.wdl" as Structs
 
 workflow SplitLargeReadGroup {
+
   input {
     File input_bam
 
@@ -36,6 +37,7 @@ workflow SplitLargeReadGroup {
     Int compression_level
     Int preemptible_tries
     Int reads_per_file = 48000000
+    Boolean hard_clip_reads = false
   }
 
   call Alignment.SamSplitter as SamSplitter {
@@ -58,7 +60,8 @@ workflow SplitLargeReadGroup {
         reference_fasta = reference_fasta,
         bwa_version = bwa_version,
         compression_level = compression_level,
-        preemptible_tries = preemptible_tries
+        preemptible_tries = preemptible_tries,
+        hard_clip_reads = hard_clip_reads
     }
 
     Float current_mapped_size = size(SamToFastqAndBwaMemAndMba.output_bam, "GiB")

--- a/tasks/UnmappedBamToAlignedBam.wdl
+++ b/tasks/UnmappedBamToAlignedBam.wdl
@@ -16,19 +16,19 @@ version 1.0
 ## page at https://hub.docker.com/r/broadinstitute/genomes-in-the-cloud/ for detailed
 ## licensing information pertaining to the included programs.
 
-import "https://raw.githubusercontent.com/gatk-workflows/gatk4-exome-analysis-pipeline/1.2.0/tasks/Alignment.wdl" as Alignment
-import "https://raw.githubusercontent.com/gatk-workflows/gatk4-exome-analysis-pipeline/1.2.0/tasks/SplitLargeReadGroup.wdl" as SplitRG
-import "https://raw.githubusercontent.com/gatk-workflows/gatk4-exome-analysis-pipeline/1.2.0/tasks/Qc.wdl" as QC
-import "https://raw.githubusercontent.com/gatk-workflows/gatk4-exome-analysis-pipeline/1.2.0/tasks/BamProcessing.wdl" as Processing
-import "https://raw.githubusercontent.com/gatk-workflows/gatk4-exome-analysis-pipeline/1.2.0/tasks/Utilities.wdl" as Utils
-import "https://raw.githubusercontent.com/gatk-workflows/gatk4-exome-analysis-pipeline/1.2.0/structs/GermlineStructs.wdl" as Structs
+import "../tasks/Alignment.wdl" as Alignment
+import "../tasks/SplitLargeReadGroup.wdl" as SplitRG
+import "../tasks/Qc.wdl" as QC
+import "../tasks/BamProcessing.wdl" as Processing
+import "../tasks/Utilities.wdl" as Utils
+import "../structs/GermlineStructs.wdl" as Structs
 
 # WORKFLOW DEFINITION
 workflow UnmappedBamToAlignedBam {
 
   input {
     SampleAndUnmappedBams sample_and_unmapped_bams
-    GermlineSingleSampleReferences references
+    DNASeqSingleSampleReferences references
     PapiSettings papi_settings
 
     File contamination_sites_ud
@@ -39,6 +39,9 @@ workflow UnmappedBamToAlignedBam {
     File? haplotype_database_file
     Float lod_threshold
     String recalibrated_bam_basename
+    Boolean hard_clip_reads = false
+    Boolean bin_base_qualities = true
+    Boolean somatic = false
   }
 
   Float cutoff_for_large_rg_in_gb = 20.0
@@ -79,7 +82,8 @@ workflow UnmappedBamToAlignedBam {
           output_bam_basename = unmapped_bam_basename + ".aligned.unsorted",
           reference_fasta = references.reference_fasta,
           compression_level = compression_level,
-          preemptible_tries = papi_settings.preemptible_tries
+          preemptible_tries = papi_settings.preemptible_tries,
+          hard_clip_reads = hard_clip_reads
       }
     }
 
@@ -93,7 +97,8 @@ workflow UnmappedBamToAlignedBam {
           reference_fasta = references.reference_fasta,
           bwa_version = GetBwaVersion.bwa_version,
           compression_level = compression_level,
-          preemptible_tries = papi_settings.preemptible_tries
+          preemptible_tries = papi_settings.preemptible_tries,
+          hard_clip_reads = hard_clip_reads
       }
     }
 
@@ -232,7 +237,9 @@ workflow UnmappedBamToAlignedBam {
         ref_fasta_index = references.reference_fasta.ref_fasta_index,
         bqsr_scatter = bqsr_divisor,
         compression_level = compression_level,
-        preemptible_tries = papi_settings.agg_preemptible_tries
+        preemptible_tries = papi_settings.agg_preemptible_tries,
+        bin_base_qualities = bin_base_qualities,
+        somatic = somatic
     }
   }
 

--- a/tasks/VariantCalling.wdl
+++ b/tasks/VariantCalling.wdl
@@ -1,9 +1,9 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/gatk-workflows/gatk4-exome-analysis-pipeline/1.2.0/tasks/GermlineVariantDiscovery.wdl" as Calling
-import "https://raw.githubusercontent.com/gatk-workflows/gatk4-exome-analysis-pipeline/1.2.0/tasks/Qc.wdl" as QC
-import "https://raw.githubusercontent.com/gatk-workflows/gatk4-exome-analysis-pipeline/1.2.0/tasks/Utilities.wdl" as Utils
-import "https://raw.githubusercontent.com/gatk-workflows/gatk4-exome-analysis-pipeline/1.2.0/tasks/BamProcessing.wdl" as BamProcessing
+import "../tasks/GermlineVariantDiscovery.wdl" as Calling
+import "../tasks/Qc.wdl" as QC
+import "../tasks/Utilities.wdl" as Utils
+import "../tasks/BamProcessing.wdl" as BamProcessing
 
 workflow VariantCalling {
 


### PR DESCRIPTION
- Updating workflow to 1.5v
- Removed import urls and left in the local directory paths, because Dockstore/Terra can now handle relative import paths.
- Increased the disk multiplier in SortSam task from the original dsde-pipeline from 3.25 to 6.25, in order for the workflow to run on Terra. Reason for this change is due to the difference in PAPI version being used in Terra vs prod. 