### PR TITLE
Missing BAM indexes causes pipeline failure during sharded BQSR

### DIFF
--- a/ExomeGermlineSingleSample.wdl
+++ b/ExomeGermlineSingleSample.wdl
@@ -125,6 +125,7 @@ workflow ExomeGermlineSingleSample {
       break_bands_at_multiples_of = scatter_settings.break_bands_at_multiples_of,
       contamination = UnmappedBamToAlignedBam.contamination,
       input_bam = UnmappedBamToAlignedBam.output_bam,
+      input_bam_index = UnmappedBamToAlignedBam.output_bam_index,
       ref_fasta = references.reference_fasta.ref_fasta,
       ref_fasta_index = references.reference_fasta.ref_fasta_index,
       ref_dict = references.reference_fasta.ref_dict,

--- a/tasks/BamProcessing.wdl
+++ b/tasks/BamProcessing.wdl
@@ -209,6 +209,7 @@ task MarkDuplicatesSpark {
 task BaseRecalibrator {
   input {
     File input_bam
+    File input_bam_index
     String recalibration_report_filename
     Array[String] sequence_group_interval
     File dbsnp_vcf
@@ -261,6 +262,7 @@ task BaseRecalibrator {
 task ApplyBQSR {
   input {
     File input_bam
+    File input_bam_index
     String output_bam_basename
     File recalibration_report
     Array[String] sequence_group_interval

--- a/tasks/GermlineVariantDiscovery.wdl
+++ b/tasks/GermlineVariantDiscovery.wdl
@@ -18,6 +18,7 @@ version 1.0
 task HaplotypeCaller_GATK35_GVCF {
   input {
     File input_bam
+    File input_bam_index
     File interval_list
     String gvcf_basename
     File ref_dict
@@ -80,6 +81,7 @@ task HaplotypeCaller_GATK35_GVCF {
 task HaplotypeCaller_GATK4_VCF {
   input {
     File input_bam
+    File input_bam_index
     File interval_list
     String vcf_basename
     File ref_dict

--- a/tasks/UnmappedBamToAlignedBam.wdl
+++ b/tasks/UnmappedBamToAlignedBam.wdl
@@ -195,6 +195,7 @@ workflow UnmappedBamToAlignedBam {
     call Processing.BaseRecalibrator as BaseRecalibrator {
       input:
         input_bam = SortSampleBam.output_bam,
+        input_bam_index = SortSampleBam.output_bam_index,
         recalibration_report_filename = sample_and_unmapped_bams.base_file_name + ".recal_data.csv",
         sequence_group_interval = subgroup,
         dbsnp_vcf = references.dbsnp_vcf,
@@ -223,6 +224,7 @@ workflow UnmappedBamToAlignedBam {
     call Processing.ApplyBQSR as ApplyBQSR {
       input:
         input_bam = SortSampleBam.output_bam,
+        input_bam_index = SortSampleBam.output_bam_index,
         output_bam_basename = recalibrated_bam_basename,
         recalibration_report = GatherBqsrReports.output_bqsr_report,
         sequence_group_interval = subgroup,

--- a/tasks/VariantCalling.wdl
+++ b/tasks/VariantCalling.wdl
@@ -14,6 +14,7 @@ workflow VariantCalling {
     Int break_bands_at_multiples_of
     Float? contamination
     File input_bam
+    File input_bam_index
     File ref_fasta
     File ref_fasta_index
     File ref_dict
@@ -53,6 +54,7 @@ workflow VariantCalling {
       call Calling.HaplotypeCaller_GATK35_GVCF as HaplotypeCallerGATK3 {
         input:
         input_bam = input_bam,
+        input_bam_index = input_bam_index,
         interval_list = scattered_interval_list,
         gvcf_basename = base_file_name,
         ref_dict = ref_dict,
@@ -71,6 +73,7 @@ workflow VariantCalling {
         input:
           contamination = contamination,
           input_bam = input_bam,
+          input_bam_index = input_bam_index,
           interval_list = scattered_interval_list,
           vcf_basename = base_file_name,
           ref_dict = ref_dict,


### PR DESCRIPTION
Issue first reported by Umang here: https://gatk.broadinstitute.org/hc/en-us/community/posts/360068718312-issue-with-gatk4-exome-analysis-pipeline-when-running-given-sample-data

Reproduced in the following environment:

- Cromwell 52 (listed as supported)
- gatk-workflows/gatk4-exome-analysis-pipeline 1.4.0 release
- Singularity backend from example
  - https://github.com/broadinstitute/cromwell/blob/develop/cromwell.example.backends/singularity.conf
